### PR TITLE
Add sender and recipient UUID handling for chat

### DIFF
--- a/Contracker/app/Events/DeviceCommand.php
+++ b/Contracker/app/Events/DeviceCommand.php
@@ -31,6 +31,7 @@ class DeviceCommand implements ShouldBroadcast, ShouldQueue
      * The public properties that will be serialized and broadcast.
      */
     public $uuid;
+    public $senderUuid;
     public string $command;
     public array $payload;
     public string $queue = 'broadcasts';
@@ -42,11 +43,12 @@ class DeviceCommand implements ShouldBroadcast, ShouldQueue
      * @param string $command
      * @param array $payload
      */
-    public function __construct($uuid, $command, array $payload)
+    public function __construct($uuid, $command, array $payload, $senderUuid = null)
     {
         $this->uuid = $uuid;
         $this->command = $command;
         $this->payload = $payload;
+        $this->senderUuid = $senderUuid;
     }
 
     /**

--- a/Contracker/app/Events/DeviceMessage.php
+++ b/Contracker/app/Events/DeviceMessage.php
@@ -27,13 +27,17 @@ class DeviceMessage implements ShouldBroadcast, ShouldQueue
     public $message;
     public $senderName;
     public $messageId; // Add an ID property to broadcast
+    public $senderUuid;
+    public $recipientUuid;
 
-    public function __construct($uuid, $message, $senderName, $messageId = null)
+    public function __construct($uuid, $message, $senderName, $messageId = null, $senderUuid = null, $recipientUuid = null)
     {
         $this->uuid = $uuid;
         $this->message = $message;
         $this->senderName = $senderName;
         $this->messageId = $messageId;
+        $this->senderUuid = $senderUuid;
+        $this->recipientUuid = $recipientUuid;
     }
 
     public function broadcastOn(): Channel

--- a/Contracker/app/Http/Controllers/MessageController.php
+++ b/Contracker/app/Http/Controllers/MessageController.php
@@ -8,21 +8,6 @@ use App\Events\DeviceCommand;
 
 class MessageController extends Controller
 {
-    /*
-    public function send(Request $request)
-    {
-        $validated = $request->validate([
-            'uuid' => 'required|string',
-            'message' => 'required|string',
-        ]);
-
-        $device = ContrackerDevice::where('uuid', $validated['uuid'])->first();
-        $deviceName = $device && $device->name ? $device->name : 'Unknown Device (' . substr($validated['uuid'], 0, 8) . ')';
-
-        broadcast(new DeviceMessage($validated['uuid'], $validated['message'], $deviceName));
-
-        return response()->json(['status' => 'Message sent']);
-    }*/
 
     public function send(Request $request)
     {
@@ -31,44 +16,48 @@ class MessageController extends Controller
             'message' => 'nullable|string',
             'messageId' => 'sometimes|string',
             'ack' => 'sometimes|boolean',
-            'status' => 'sometimes|string'
+            'status' => 'sometimes|string',
+            'typing' => 'sometimes|boolean',
+            'sender_uuid' => 'sometimes|string',
+            'recipient_uuid' => 'sometimes|string'
         ]);
 
         $deviceUuid = $validated['uuid'];
         $text = $validated['message'] ?? '';
+        $senderUuid = $validated['sender_uuid'] ?? $deviceUuid;
+        $recipientUuid = $validated['recipient_uuid'] ?? 'admin';
 
         if (!empty($validated['ack']) && isset($validated['messageId'], $validated['status'])) {
             // This is an acknowledgment from a device that a message was delivered/read.
             broadcast(new DeviceCommand($deviceUuid, 'ack', [
                 'messageId' => $validated['messageId'],
-                'status' => $validated['status']
-            ]));
+                'status' => $validated['status'],
+                'recipient_uuid' => $recipientUuid
+            ], $senderUuid));
             return response()->json(['status' => 'ACK broadcast']);
         }
 
-        // Within MessageController@send, at top where we handle ACKs:
-        if (!empty($validated['ack']) && !empty($validated['typing'])) {
+        if (!empty($validated['typing'])) {
             // Device is notifying that it is typing
-            broadcast(new DeviceCommand($deviceUuid, 'typing', []));
+            broadcast(new DeviceCommand($deviceUuid, 'typing', ['recipient_uuid' => $recipientUuid], $senderUuid));
             return response()->json(['status' => 'Typing signal sent']);
         }
 
-        // Determine sender and receiver for storage
+        // Determine sender information for storage
         $senderId = $request->input('uuid') ?: 'device'; // Use device UUID as sender ID
-        $receiverId = $request->user() ? 'admin' : 'admin'; // In this context, device posts to admin (admin as receiver)
         $senderName = 'Device';
         if ($device = \App\Models\ContrackerDevice::where('uuid', $deviceUuid)->first()) {
             $senderName = $device->name ?: 'Device';
         }
 
         // Broadcast DeviceMessage event to admin listeners
-        broadcast(new DeviceMessage($deviceUuid, $text, $senderName, $validated['messageId'] ?? null));
+        broadcast(new DeviceMessage($deviceUuid, $text, $senderName, $validated['messageId'] ?? null, $senderUuid, $recipientUuid));
 
         // Store the message in the database for history/search (as not read yet by admin)
         \Illuminate\Support\Facades\DB::table('contracker_messages')->insert([
             'conversation_id' => $deviceUuid,
-            'sender_id' => $deviceUuid,
-            'receiver_id' => 'admin',   // assuming single-admin scenario
+            'sender_id' => $senderUuid,
+            'receiver_id' => $recipientUuid,
             'message' => $text,
             'created_at' => now(),
             'updated_at' => now(),

--- a/Contracker/app/Http/Controllers/SessionController.php
+++ b/Contracker/app/Http/Controllers/SessionController.php
@@ -240,12 +240,15 @@ class SessionController extends Controller
     {
         $validated = $request->validate([
             'command' => 'required|string',
-            'payload' => 'sometimes|array'
+            'payload' => 'sometimes|array',
+            'sender_uuid' => 'sometimes|string'
         ]);
+
+        $senderUuid = $validated['sender_uuid'] ?? null;
 
         if ($validated['command'] === 'typing') {
             // Admin typing indicator
-            broadcast(new DeviceCommand($uuid, 'typing', []));
+            broadcast(new DeviceCommand($uuid, 'typing', [], $senderUuid));
             return response()->json(['status' => 'Typing signal broadcast']);
         }
 
@@ -256,13 +259,14 @@ class SessionController extends Controller
             // Broadcast chat message to the device's channel
             broadcast(new DeviceCommand($uuid, 'message', [
                 'message' => $messageText,
-                'messageId' => $messageId
-            ]));
-            $senderId = $request->input('uuid');
+                'messageId' => $messageId,
+                'recipient_uuid' => $uuid
+            ], $senderUuid));
+            $senderId = $senderUuid;
             // Store in DB for history (sender is admin, receiver is device)
             \Illuminate\Support\Facades\DB::table('contracker_messages')->insert([
                 'conversation_id' => $uuid,
-                'sender_id' => $senderId, //$request->user()->id ?? 'admin',
+                'sender_id' => $senderId,
                 'receiver_id' => $uuid,
                 'message' => $messageText,
                 'created_at' => now(),
@@ -273,7 +277,7 @@ class SessionController extends Controller
         }
 
         // If this is an acknowledgment or other command (typing, ack, etc.)
-        broadcast(new DeviceCommand($uuid, $validated['command'], $validated['payload'] ?? []));
+        broadcast(new DeviceCommand($uuid, $validated['command'], $validated['payload'] ?? [], $senderUuid));
         return response()->json(['status' => 'Command sent']);
     }
 

--- a/Contracker/resources/js/Components/ChatInput.jsx
+++ b/Contracker/resources/js/Components/ChatInput.jsx
@@ -26,9 +26,11 @@ const ChatInput = ({ uuid, auth, onMessageSent }) => {
         setMessage('');
         try {
             // Send the message to the backend (DeviceCommand with command 'message')
+            const senderUuid = localStorage.getItem('device_uuid');
             await axios.post(route('session.device.command', { uuid }), {
+                sender_uuid: senderUuid,
                 command: 'message',
-                payload: { message: trimmed, messageId: tempId }
+                payload: { message: trimmed, messageId: tempId, recipient_uuid: uuid }
             });
             console.log('ChatInput: Message sent to backend successfully.');
             // Upon success, we could update status to "sent", but the ACK from device will mark delivered.
@@ -55,9 +57,11 @@ const ChatInput = ({ uuid, auth, onMessageSent }) => {
         // Notify that the admin is typing (throttle to send infrequently)
         if (window.Echo && window.Echo.connector && window.Echo.connector.pusher) {
             try {
+                const senderUuid = localStorage.getItem('device_uuid');
                 axios.post(route('session.device.command', { uuid }), {
+                    sender_uuid: senderUuid,
                     command: 'typing',
-                    payload: {}
+                    payload: { recipient_uuid: uuid }
                 });
             } catch (err) {
                 console.error('Failed to send typing indicator', err);

--- a/Contracker/resources/js/Components/DeviceChatInput.jsx
+++ b/Contracker/resources/js/Components/DeviceChatInput.jsx
@@ -21,6 +21,8 @@ const DeviceChatInput = ({ uuid, onMessageSent }) => {
             // Send message to backend (Device -> Admin)
             await axios.post(route('devices.message.send'), {
                 uuid,
+                sender_uuid: localStorage.getItem('device_uuid'),
+                recipient_uuid: 'admin',
                 message: trimmed,
                 messageId: tempId
             });
@@ -48,6 +50,8 @@ const DeviceChatInput = ({ uuid, onMessageSent }) => {
         try {
             axios.post(route('devices.message.send'), {
                 uuid,
+                sender_uuid: localStorage.getItem('device_uuid'),
+                recipient_uuid: 'admin',
                 message: '',    // no actual message
                 ack: true,
                 typing: true    // custom flag to indicate typing

--- a/Contracker/resources/js/Components/PersistentChatWindow.jsx
+++ b/Contracker/resources/js/Components/PersistentChatWindow.jsx
@@ -74,7 +74,7 @@ const PersistentChatWindow = ({ chat, auth, onClose, onMinimize, onMessageSent }
     };
 
     return (
-        <div className="w-80 h-[28rem] bg-white dark:bg-gray-800 rounded-t-lg shadow-2xl flex flex-col">
+        <div className={`w-80 ${chat.minimized ? 'h-auto' : 'h-[28rem]'} bg-white dark:bg-gray-800 rounded-t-lg shadow-2xl flex flex-col`}>
             {/* Header */}
             <div onClick={onMinimize} className="flex justify-between items-center p-2 bg-gray-700 dark:bg-gray-900 text-white rounded-t-lg cursor-pointer">
                 <h3 className="font-semibold text-sm truncate">{chat.name || chat.uuid}</h3>

--- a/Contracker/routes/channels.php
+++ b/Contracker/routes/channels.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,11 +18,14 @@ use Illuminate\Support\Facades\Log;
 // By removing the `$user` type-hint and always returning true, we allow
 // any client (even non-authenticated ones) to subscribe to this channel.
 // This is essential for your remote devices to receive messages.
+Route::post('/broadcasting/auth', function () {
+    return Broadcast::auth(request());
+})->middleware('web');
+
 Broadcast::channel('device.{uuid}', function ($user = null, $uuid) {
     Log::info("Broadcasting authorization attempt for device UUID: {$uuid}");
 
     // In a real production environment, you would add security here,
     // for example, checking if the UUID exists in your database.
     // For now, we allow any device to connect for debugging purposes.
-    return true;
-});
+    return true;});


### PR DESCRIPTION
## Summary
- include `sender_uuid` and `recipient_uuid` when sending chat messages
- store these identifiers in `SessionController` and `MessageController`
- update `DeviceCommand` and `DeviceMessage` events for new fields
- allow unauthenticated broadcasting auth
- improve chat window minimise height
- clean up MessageController validation and remove old code

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686deaaba8dc8327aa144c50b93e6a8e