### PR TITLE
Add typing field validation

### DIFF
--- a/Contracker/resources/js/Components/ChatManager.jsx
+++ b/Contracker/resources/js/Components/ChatManager.jsx
@@ -170,6 +170,8 @@ const ChatManager = ({ auth }) => {
                         timestamp: new Date(),
                         status: 'delivered'  // delivered to admin client
                     };
+                    // Ensure the chat is visible when a new message arrives
+                    openChat(device);
                     addMessage(device.uuid, msg);
                 });
                 // Listen for device acknowledgments (read/delivered receipts or typing indicators)


### PR DESCRIPTION
## Summary
- allow `typing` parameter in `MessageController::send`
- fix message sending branch order
- open admin chat UI when a device sends a message

## Testing
- `npm test` *(fails: missing script)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686e0e6f371483278b8238262f2aabc1