### PR TITLE
Add cost code allocation schema

### DIFF
--- a/Contracker/app/Models/ContrackerCostCode.php
+++ b/Contracker/app/Models/ContrackerCostCode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContrackerCostCode extends Model
+{
+    protected $table = 'contracker_cost_codes';
+
+    protected $fillable = [
+        'job_id',
+        'code',
+        'name',
+        'description',
+    ];
+
+    public function job()
+    {
+        return $this->belongsTo(ContrackerJob::class, 'job_id');
+    }
+
+    public function assignments()
+    {
+        return $this->hasMany(ContrackerCostCodeAssignment::class, 'cost_code_id');
+    }
+}

--- a/Contracker/app/Models/ContrackerCostCodeAssignment.php
+++ b/Contracker/app/Models/ContrackerCostCodeAssignment.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContrackerCostCodeAssignment extends Model
+{
+    protected $table = 'contracker_cost_code_assignments';
+
+    protected $fillable = [
+        'job_id',
+        'timecard_id',
+        'laborer_id',
+        'cost_code_id',
+        'hours',
+        'note',
+    ];
+
+    public function job()
+    {
+        return $this->belongsTo(ContrackerJob::class, 'job_id');
+    }
+
+    public function laborer()
+    {
+        return $this->belongsTo(ContrackerLaborer::class, 'laborer_id');
+    }
+
+    public function costCode()
+    {
+        return $this->belongsTo(ContrackerCostCode::class, 'cost_code_id');
+    }
+
+    public function timecard()
+    {
+        // relation will be defined once ContrackerTimecard model exists
+        return $this->belongsTo(ContrackerTimecard::class, 'timecard_id');
+    }
+}

--- a/Contracker/app/Models/ContrackerLaborer.php
+++ b/Contracker/app/Models/ContrackerLaborer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContrackerLaborer extends Model
+{
+    protected $table = 'contracker_laborers';
+
+    protected $fillable = [
+        'job_id',
+        'name',
+        'local',
+        'original_hours',
+        'clock_in_time',
+        'clock_out_time',
+    ];
+
+    public function job()
+    {
+        return $this->belongsTo(ContrackerJob::class, 'job_id');
+    }
+
+    public function assignments()
+    {
+        return $this->hasMany(ContrackerCostCodeAssignment::class, 'laborer_id');
+    }
+}

--- a/Contracker/app/Models/ContrackerTimecard.php
+++ b/Contracker/app/Models/ContrackerTimecard.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ContrackerTimecard extends Model
+{
+    protected $table = 'contracker_timecards';
+
+    protected $fillable = [
+        // TODO: define fillable attributes for timecards
+    ];
+
+    // Relationships will be added when table structure is defined
+}

--- a/Contracker/database/migrations/2025_07_09_000000_create_contracker_cost_codes_table.php
+++ b/Contracker/database/migrations/2025_07_09_000000_create_contracker_cost_codes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('contracker_cost_codes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('job_id');
+            $table->string('code');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+
+            $table->foreign('job_id')->references('id')->on('contracker_jobs')->onDelete('cascade');
+            $table->unique(['job_id', 'code']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('contracker_cost_codes');
+    }
+};

--- a/Contracker/database/migrations/2025_07_09_000100_create_contracker_laborers_table.php
+++ b/Contracker/database/migrations/2025_07_09_000100_create_contracker_laborers_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('contracker_laborers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('job_id');
+            $table->string('name');
+            $table->string('local')->nullable();
+            $table->decimal('original_hours', 5, 2)->default(0);
+            $table->time('clock_in_time')->nullable();
+            $table->time('clock_out_time')->nullable();
+            $table->timestamps();
+
+            $table->foreign('job_id')->references('id')->on('contracker_jobs')->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('contracker_laborers');
+    }
+};

--- a/Contracker/database/migrations/2025_07_09_000200_create_contracker_cost_code_assignments_table.php
+++ b/Contracker/database/migrations/2025_07_09_000200_create_contracker_cost_code_assignments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('contracker_cost_code_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('job_id');
+            $table->unsignedBigInteger('timecard_id')->nullable(); // TODO: add foreign key to contracker_timecards when table is created
+            $table->unsignedBigInteger('laborer_id');
+            $table->unsignedBigInteger('cost_code_id');
+            $table->decimal('hours', 5, 2)->default(0);
+            $table->text('note')->nullable();
+            $table->timestamps();
+
+            $table->foreign('job_id')->references('id')->on('contracker_jobs')->onDelete('cascade');
+            $table->foreign('laborer_id')->references('id')->on('contracker_laborers')->onDelete('cascade');
+            $table->foreign('cost_code_id')->references('id')->on('contracker_cost_codes')->onDelete('cascade');
+            // foreign key for timecard_id will be added once contracker_timecards exists
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('contracker_cost_code_assignments');
+    }
+};

--- a/Contracker/database/migrations/2025_07_09_000300_create_contracker_timecards_table.php
+++ b/Contracker/database/migrations/2025_07_09_000300_create_contracker_timecards_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        // TODO: Define contracker_timecards table structure
+        Schema::create('contracker_timecards', function (Blueprint $table) {
+            $table->id();
+            // $table->unsignedBigInteger('job_id'); // Example column
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('contracker_timecards');
+    }
+};


### PR DESCRIPTION
## Summary
- add contracker_cost_codes migration
- add contracker_laborers migration
- add contracker_cost_code_assignments migration
- stub contracker_timecards table
- add Eloquent models for cost codes, laborers, assignments, and timecards

## Testing
- `php -l database/migrations/2025_07_09_000000_create_contracker_cost_codes_table.php`
- `php -l database/migrations/2025_07_09_000100_create_contracker_laborers_table.php`
- `php -l database/migrations/2025_07_09_000200_create_contracker_cost_code_assignments_table.php`
- `php -l database/migrations/2025_07_09_000300_create_contracker_timecards_table.php`
- `php -l app/Models/ContrackerCostCode.php`
- `php -l app/Models/ContrackerLaborer.php`
- `php -l app/Models/ContrackerCostCodeAssignment.php`
- `php -l app/Models/ContrackerTimecard.php`


------
https://chatgpt.com/codex/tasks/task_e_6872a27502a483278eac37c9230e61f6