### PR TITLE
Improve device status logic

### DIFF
--- a/Contracker/app/Http/Controllers/MessageController.php
+++ b/Contracker/app/Http/Controllers/MessageController.php
@@ -68,7 +68,11 @@ class MessageController extends Controller
             'read_at' => null,
         ]);
 
-        Log::info();
+        Log::info('Chat message stored', [
+            'device_uuid' => $deviceUuid,
+            'sender' => $senderUuid,
+            'recipient' => $recipientUuid,
+        ]);
 
         return response()->json(['status' => 'Message sent']);
     }

--- a/Contracker/app/Http/Controllers/SessionController.php
+++ b/Contracker/app/Http/Controllers/SessionController.php
@@ -113,8 +113,8 @@ class SessionController extends Controller
                 return response()->json(['error' => 'Job location not found'], 404);
             }*/
 
-            // Custom distance threshold (meters)
-            $distanceThreshold = 200;
+            // Distance threshold in meters (configurable)
+            $distanceThreshold = config('contracker.distance_threshold', 200);
 
             // Calculate distance using Haversine formula
             $distance = DB::select("
@@ -222,13 +222,7 @@ class SessionController extends Controller
 
     public function listDevices(Request $request)
     {
-        /** @var \Carbon\Carbon $now */
-        $now = now();
-        $devices = ContrackerDevice::with(['jobLocation.job'])->get()->map(function ($device) use ($now) {
-            $device->online = $device->last_seen && ($now->diffInMinutes($device->last_seen)*-1) <= 3; // Device is online if last seen within 5 minutes
-            $device->last_ping = $now->diffInMinutes($device->last_seen)*-1;
-            return $device;
-        });
+        $devices = ContrackerDevice::with(['jobLocation.job'])->get();
 
         if ($request->wantsJson()) {
             return response()->json(['devices' => $devices]);

--- a/Contracker/config/contracker.php
+++ b/Contracker/config/contracker.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    'online_threshold' => env('CONTRACKER_ONLINE_THRESHOLD', 5), // minutes
+    'distance_threshold' => env('CONTRACKER_DISTANCE_THRESHOLD', 200), // meters
+];
+


### PR DESCRIPTION
## Summary
- add contracker config for thresholds
- expose device online/last_ping attributes and helper scope
- use new attributes in SessionController
- log message info when storing chat message

## Testing
- `php -l Contracker/app/Models/ContrackerDevice.php`
- `php -l Contracker/app/Http/Controllers/SessionController.php`
- `php -l Contracker/app/Http/Controllers/MessageController.php`
- `./vendor/bin/phpunit --configuration phpunit.xml --testsuite Unit --stop-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6889381d62f8832788cb01a5efefa03b