### PR TITLE
Add geofence admin page and timeclock feature

### DIFF
--- a/Contracker/app/Http/Controllers/SessionController.php
+++ b/Contracker/app/Http/Controllers/SessionController.php
@@ -189,6 +189,24 @@ class SessionController extends Controller
         return response()->json(['status' => 'Geofence saved!', 'geofence' => $geofence]);
     }
 
+    public function listGeofences()
+    {
+        $geofences = ContrackerJobLocation::with(['job', 'geofence'])
+            ->whereHas('geofence')
+            ->get()
+            ->map(function ($loc) {
+                return [
+                    'job_id' => $loc->job_id,
+                    'job_no' => $loc->job ? $loc->job->job_no : null,
+                    'latitude' => $loc->latitude,
+                    'longitude' => $loc->longitude,
+                    'boundary_points' => optional($loc->geofence)->boundary_points,
+                ];
+            });
+
+        return response()->json($geofences);
+    }
+
     public function updateDeviceName(Request $request, $uuid)
     {
         $validated = $request->validate([

--- a/Contracker/app/Http/Controllers/TimeclockController.php
+++ b/Contracker/app/Http/Controllers/TimeclockController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TimeEntry;
+use App\Models\ContrackerDevice;
+use App\Models\ContrackerJob;
+use App\Models\ContrackerJobLocation;
+use Illuminate\Http\Request;
+
+class TimeclockController extends Controller
+{
+    public function clockIn(Request $request, $jobId, $uuid)
+    {
+        $request->validate([
+            'latitude' => 'required|numeric',
+            'longitude' => 'required|numeric',
+        ]);
+
+        $device = ContrackerDevice::where('uuid', $uuid)->firstOrFail();
+        $job = ContrackerJob::findOrFail($jobId);
+
+        // Check geofence
+        $location = ContrackerJobLocation::with('geofence')->where('job_id', $job->id)->first();
+        if ($location && $location->geofence) {
+            $points = json_decode($location->geofence->boundary_points, true);
+            if (!$this->pointInPolygon($request->latitude, $request->longitude, $points)) {
+                return response()->json(['error' => 'Device not within geofence'], 403);
+            }
+        }
+
+        $existing = TimeEntry::where('device_id', $device->id)
+            ->where('job_id', $job->id)
+            ->whereNull('end_time')
+            ->first();
+        if ($existing) {
+            return response()->json(['error' => 'Already clocked in'], 409);
+        }
+
+        $entry = TimeEntry::create([
+            'device_id' => $device->id,
+            'job_id' => $job->id,
+            'start_time' => now(),
+            'face_in' => $request->input('face_in'),
+            'signature_in' => $request->input('signature_in'),
+        ]);
+
+        return response()->json($entry, 201);
+    }
+
+    public function clockOut(Request $request, $jobId, $uuid)
+    {
+        $request->validate([
+            'latitude' => 'required|numeric',
+            'longitude' => 'required|numeric',
+        ]);
+
+        $device = ContrackerDevice::where('uuid', $uuid)->firstOrFail();
+        $job = ContrackerJob::findOrFail($jobId);
+
+        $entry = TimeEntry::where('device_id', $device->id)
+            ->where('job_id', $job->id)
+            ->whereNull('end_time')
+            ->first();
+        if (!$entry) {
+            return response()->json(['error' => 'No active entry'], 404);
+        }
+
+        // Geofence check
+        $location = ContrackerJobLocation::with('geofence')->where('job_id', $job->id)->first();
+        if ($location && $location->geofence) {
+            $points = json_decode($location->geofence->boundary_points, true);
+            if (!$this->pointInPolygon($request->latitude, $request->longitude, $points)) {
+                return response()->json(['error' => 'Device not within geofence'], 403);
+            }
+        }
+
+        $entry->update([
+            'end_time' => now(),
+            'face_out' => $request->input('face_out'),
+            'signature_out' => $request->input('signature_out'),
+        ]);
+
+        return response()->json($entry);
+    }
+
+    public function currentEntry($jobId, $uuid)
+    {
+        $device = ContrackerDevice::where('uuid', $uuid)->firstOrFail();
+        $entry = TimeEntry::where('device_id', $device->id)
+            ->where('job_id', $jobId)
+            ->whereNull('end_time')
+            ->first();
+        return response()->json($entry);
+    }
+
+    private function distance($lat1, $lon1, $lat2, $lon2)
+    {
+        $earthRadius = 6371000; // meters
+        $dLat = deg2rad($lat2 - $lat1);
+        $dLon = deg2rad($lon2 - $lon1);
+        $a = sin($dLat/2) * sin($dLat/2) +
+            cos(deg2rad($lat1)) * cos(deg2rad($lat2)) *
+            sin($dLon/2) * sin($dLon/2);
+        $c = 2 * atan2(sqrt($a), sqrt(1-$a));
+        return $earthRadius * $c;
+    }
+
+    private function pointInPolygon($lat, $lng, array $polygon): bool
+    {
+        $inside = false;
+        $points = count($polygon);
+        for ($i = 0, $j = $points - 1; $i < $points; $j = $i++) {
+            $xi = $polygon[$i][0];
+            $yi = $polygon[$i][1];
+            $xj = $polygon[$j][0];
+            $yj = $polygon[$j][1];
+
+            $intersect = (($yi > $lng) != ($yj > $lng)) &&
+                ($lat < ($xj - $xi) * ($lng - $yi) / ($yj - $yi + 0.0000001) + $xi);
+            if ($intersect) {
+                $inside = !$inside;
+            }
+        }
+        return $inside;
+    }
+}

--- a/Contracker/app/Models/TimeEntry.php
+++ b/Contracker/app/Models/TimeEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TimeEntry extends Model
+{
+    protected $fillable = [
+        'device_id',
+        'job_id',
+        'start_time',
+        'end_time',
+        'face_in',
+        'signature_in',
+        'face_out',
+        'signature_out',
+    ];
+
+    protected $casts = [
+        'start_time' => 'datetime',
+        'end_time' => 'datetime',
+    ];
+
+    public function device()
+    {
+        return $this->belongsTo(ContrackerDevice::class, 'device_id');
+    }
+
+    public function job()
+    {
+        return $this->belongsTo(ContrackerJob::class, 'job_id');
+    }
+}

--- a/Contracker/database/migrations/2025_07_29_000000_create_time_entries_table.php
+++ b/Contracker/database/migrations/2025_07_29_000000_create_time_entries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('time_entries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('device_id');
+            $table->unsignedBigInteger('job_id');
+            $table->timestamp('start_time');
+            $table->timestamp('end_time')->nullable();
+            $table->text('face_in')->nullable();
+            $table->text('signature_in')->nullable();
+            $table->text('face_out')->nullable();
+            $table->text('signature_out')->nullable();
+            $table->timestamps();
+
+            $table->foreign('device_id')->references('id')->on('contracker_devices')->onDelete('cascade');
+            $table->foreign('job_id')->references('id')->on('contracker_jobs')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('time_entries');
+    }
+};

--- a/Contracker/resources/js/Layouts/AppLayout.jsx
+++ b/Contracker/resources/js/Layouts/AppLayout.jsx
@@ -32,6 +32,15 @@ export default function AppLayout({ header, children }) {
                                 <NavLink href={route('devices.list')} active={route().current('devices.list')}>
                                     Device Management
                                 </NavLink>
+                                <NavLink href={route('jobs.list')} active={route().current('jobs.list')}>
+                                    Jobs
+                                </NavLink>
+                                <NavLink href={route('geofences.admin')} active={route().current('geofences.admin')}>
+                                    Geofences
+                                </NavLink>
+                                <NavLink href={route('timeclock')} active={route().current('timeclock')}>
+                                    Timeclock
+                                </NavLink>
                                 <NavLink href={route('messages.search')} active={route().current('messages.search')}>
                                     Message Search
                                 </NavLink>

--- a/Contracker/resources/js/Pages/GeofenceAdmin.jsx
+++ b/Contracker/resources/js/Pages/GeofenceAdmin.jsx
@@ -1,0 +1,38 @@
+import 'leaflet/dist/leaflet.css';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { MapContainer, TileLayer, Polygon, Popup } from 'react-leaflet';
+import AppLayout from '@/Layouts/AppLayout';
+
+export default function GeofenceAdmin() {
+  const [geofences, setGeofences] = useState([]);
+
+  useEffect(() => {
+    axios.get('/session/geofences').then(r => setGeofences(r.data));
+  }, []);
+
+  const center = geofences.length > 0
+    ? [geofences[0].latitude, geofences[0].longitude]
+    : [0, 0];
+
+  return (
+    <AppLayout header={<h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Geofences</h2>}>
+      <div className="p-4">
+        <MapContainer center={center} zoom={6} style={{ height: '600px', width: '100%' }}>
+          <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+          {geofences.map(f => {
+            let points = f.boundary_points;
+            if (typeof points === 'string') {
+              try { points = JSON.parse(points); } catch (e) { points = []; }
+            }
+            return (
+              <Polygon key={f.job_id} positions={points} color="blue">
+                <Popup>{f.job_no || 'Job ' + f.job_id}</Popup>
+              </Polygon>
+            );
+          })}
+        </MapContainer>
+      </div>
+    </AppLayout>
+  );
+}

--- a/Contracker/resources/js/Pages/Timeclock.jsx
+++ b/Contracker/resources/js/Pages/Timeclock.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import AppLayout from '@/Layouts/AppLayout';
+import axios from 'axios';
+
+export default function Timeclock() {
+  const [jobId, setJobId] = useState('');
+  const [uuid, setUuid] = useState('');
+  const [message, setMessage] = useState('');
+
+  const clockIn = async () => {
+    try {
+      await axios.post(`/timeclock/jobs/${jobId}/devices/${uuid}/clock-in`, { latitude: 0, longitude: 0 });
+      setMessage('Clocked in');
+    } catch (e) {
+      setMessage('Error clocking in');
+    }
+  };
+
+  const clockOut = async () => {
+    try {
+      await axios.post(`/timeclock/jobs/${jobId}/devices/${uuid}/clock-out`, { latitude: 0, longitude: 0 });
+      setMessage('Clocked out');
+    } catch (e) {
+      setMessage('Error clocking out');
+    }
+  };
+
+  return (
+    <AppLayout header={<h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Timeclock</h2>}>
+      <div className="p-4 space-y-4">
+        <div>
+          <label className="block">Job ID</label>
+          <input className="border" value={jobId} onChange={e => setJobId(e.target.value)} />
+        </div>
+        <div>
+          <label className="block">Device UUID</label>
+          <input className="border" value={uuid} onChange={e => setUuid(e.target.value)} />
+        </div>
+        <button onClick={clockIn} className="px-4 py-2 bg-green-500 text-white">Clock In</button>
+        <button onClick={clockOut} className="px-4 py-2 bg-red-500 text-white ml-2">Clock Out</button>
+        <div>{message}</div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/Contracker/routes/web.php
+++ b/Contracker/routes/web.php
@@ -58,6 +58,15 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return Inertia::render('Geofence', ['jobId' => $jobId]);
     })->name('geofence');
 
+    // Admin overview of all geofences
+    Route::get('/geofences', function () {
+        return Inertia::render('GeofenceAdmin');
+    })->name('geofences.admin');
+
+    Route::get('/timeclock', function () {
+        return Inertia::render('Timeclock');
+    })->name('timeclock');
+
     Route::get('/jobs/{jobId}/allocator', [CostCodeAllocatorController::class, 'index'])->name('costcode.allocator');
     Route::get('/session/jobs/{jobId}/allocator-data', [CostCodeAllocatorController::class, 'data'])->name('costcode.allocator.data');
 
@@ -114,6 +123,12 @@ Route::middleware('web')->group(function () {
     Route::get('/session/jobs', [SessionController::class, 'getJobs'])->name('session.getJobs');
     Route::get('/session/job-location/{jobId}', [SessionController::class, 'getJobLocation'])->name('session.getJobLocation');
     Route::post('/session/save-geofence', [SessionController::class, 'saveGeofence'])->name('session.saveGeofence');
+    Route::get('/session/geofences', [SessionController::class, 'listGeofences'])->name('session.listGeofences');
+
+    // Timeclock endpoints (no auth required)
+    Route::post('/timeclock/jobs/{job}/devices/{uuid}/clock-in', [\App\Http\Controllers\TimeclockController::class, 'clockIn']);
+    Route::post('/timeclock/jobs/{job}/devices/{uuid}/clock-out', [\App\Http\Controllers\TimeclockController::class, 'clockOut']);
+    Route::get('/timeclock/jobs/{job}/devices/{uuid}', [\App\Http\Controllers\TimeclockController::class, 'currentEntry']);
 
 
 


### PR DESCRIPTION
## Summary
- create `time_entries` table and TimeEntry model
- implement TimeclockController with geofence enforcement
- expose API to list all geofences and added routes for clock-in/out
- add GeofenceAdmin and Timeclock pages
- update navigation links

## Testing
- `php artisan test` *(fails: vendor not installed)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68893a8ab7288327a8ceab23fb37348a