### PR TITLE
Add standalone clock-in keypad

### DIFF
--- a/Contracker/public/clockin/index.html
+++ b/Contracker/public/clockin/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Clock In</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="container">
+<section id="ssn">
+  <input type="text" id="ssnInput" maxlength="6" placeholder="LAST 6 OF SSN" />
+</section>
+<div class="keypad">
+  <button class="key" value="1">1</button>
+  <button class="key" value="2">2</button>
+  <button class="key" value="3">3</button>
+  <button class="key" value="4">4</button>
+  <button class="key" value="5">5</button>
+  <button class="key" value="6">6</button>
+  <button class="key" value="7">7</button>
+  <button class="key" value="8">8</button>
+  <button class="key" value="9">9</button>
+  <button class="key" value="clr">&times;</button>
+  <button class="key" value="0">0</button>
+  <button class="key" value="del">&#9003;</button>
+  <button class="clock" value="clock">CLOCK IN</button>
+</div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/Contracker/public/clockin/script.js
+++ b/Contracker/public/clockin/script.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ssnInput = document.getElementById('ssnInput');
+  ssnInput.focus();
+
+  document.querySelectorAll('.keypad .key').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      const value = btn.value;
+      if (value === 'clr') {
+        ssnInput.value = '';
+        return;
+      }
+      if (value === 'del') {
+        ssnInput.value = ssnInput.value.slice(0, -1);
+        return;
+      }
+      if (ssnInput.value.length < 6 && /^\d$/.test(value)) {
+        ssnInput.value += value;
+      }
+    });
+  });
+
+  document.addEventListener('keydown', e => {
+    const val = ssnInput.value;
+    if (e.key === 'Backspace') {
+      e.preventDefault();
+      ssnInput.value = val.slice(0, -1);
+      return;
+    }
+    if (e.key === 'Delete') {
+      ssnInput.value = '';
+      e.preventDefault();
+      return;
+    }
+    if (val.length >= 6) {
+      e.preventDefault();
+      return;
+    }
+    if (/\d/.test(e.key)) {
+      e.preventDefault();
+      ssnInput.value += e.key;
+    }
+  });
+});

--- a/Contracker/public/clockin/style.css
+++ b/Contracker/public/clockin/style.css
@@ -1,0 +1,72 @@
+*, html {
+  font-family: "Montserrat", serif;
+  font-weight: 100;
+  font-style: normal;
+}
+
+.container {
+  margin: 0 auto;
+  width: 400px;
+  text-align: center;
+}
+
+.keypad {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  column-gap: 30px;
+  row-gap: 20px;
+  max-width: 400px;
+}
+
+.keypad button {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  font-size: 2rem;
+  font-weight: 300;
+  border: 0;
+  background: #ddd;
+  cursor: pointer;
+}
+
+.keypad button.clock {
+  margin-top: 30px;
+  border-radius: 30px;
+  background: #74C565;
+  font-weight: 300;
+  flex-basis: 90%;
+  font-size: 3rem;
+  color: white;
+  letter-spacing: .5rem;
+}
+
+button:hover {
+  background: rgba(100,100,100,.5);
+}
+
+#ssn {
+  width: 100%;
+  padding-bottom: 30px;
+}
+
+#ssnInput {
+  width: 100%;
+  height: 100px;
+  text-align: center;
+  font-size: 3rem;
+  font-weight: 200;
+  margin: 0;
+  letter-spacing: 30px;
+  border: none;
+}
+
+#ssnInput:focus {
+  margin-right: -30px;
+  outline: none;
+}
+
+#ssnInput::placeholder {
+  font-size: 2rem;
+  letter-spacing: 1px;
+}


### PR DESCRIPTION
## Summary
- add a static clock-in page with keypad input

## Testing
- `composer test` *(fails: missing vendor packages)*

------
https://chatgpt.com/codex/tasks/task_e_688949fede8c83278ddddc748730cff3