### PR TITLE
Implement sidebar layout and full cost code allocator

### DIFF
--- a/Contracker/database/seeders/ContrackerDemoSeeder.php
+++ b/Contracker/database/seeders/ContrackerDemoSeeder.php
@@ -1,0 +1,62 @@
+<?php
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ContrackerJob;
+use App\Models\ContrackerCostCode;
+use App\Models\ContrackerLaborer;
+use App\Models\ContrackerCostCodeAssignment;
+
+class ContrackerDemoSeeder extends Seeder
+{
+    public function run()
+    {
+        $job = ContrackerJob::create([
+            'job_no' => 'OFF-001',
+            'description' => 'Demo Office Build',
+            'address_1' => '1 Demo Way',
+            'city' => 'DemoCity',
+            'state' => 'NY',
+            'zip' => '10001',
+            'contract_id' => 1,
+            'client_id' => 1,
+            'project_class_no' => 1,
+            'project_manager_id' => 1,
+        ]);
+
+        $codes = [
+            ['code' => 'S10001-001', 'name' => 'Carpentry'],
+            ['code' => 'S10001-002', 'name' => 'Plumbing'],
+            ['code' => 'S10001-003', 'name' => 'Electrical'],
+        ];
+        foreach ($codes as $c) {
+            ContrackerCostCode::create(array_merge($c, ['job_id' => $job->id]));
+        }
+
+        $laborers = [
+            ['name' => 'John Smith', 'local' => 'Local79'],
+            ['name' => 'Jane Doe', 'local' => 'Local79'],
+            ['name' => 'Bob Brown', 'local' => 'Local102'],
+        ];
+        foreach ($laborers as $l) {
+            ContrackerLaborer::create([
+                'job_id' => $job->id,
+                'name' => $l['name'],
+                'local' => $l['local'],
+                'original_hours' => 10,
+                'clock_in_time' => '07:00:00',
+                'clock_out_time' => '17:00:00',
+            ]);
+        }
+
+        // assignments optional demo
+        $lab = ContrackerLaborer::first();
+        $cc = ContrackerCostCode::first();
+        ContrackerCostCodeAssignment::create([
+            'job_id' => $job->id,
+            'laborer_id' => $lab->id,
+            'cost_code_id' => $cc->id,
+            'hours' => 10,
+        ]);
+    }
+}

--- a/Contracker/database/seeders/DatabaseSeeder.php
+++ b/Contracker/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\ContrackerDemoSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(ContrackerDemoSeeder::class);
     }
 }

--- a/Contracker/resources/js/Allocator/FullCostCodeAllocator.jsx
+++ b/Contracker/resources/js/Allocator/FullCostCodeAllocator.jsx
@@ -1,0 +1,98 @@
+// Adapted version of the CodePen allocator for use with React/Vite
+import React, { useState, useMemo } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+
+function AssignmentCard({ assignment, meta, onRemove }) {
+    return (
+        <div className="bg-white rounded shadow p-2 mb-2 flex justify-between">
+            <div>
+                <h4 className="font-semibold text-sm">{meta.name}</h4>
+                <p className="text-xs text-gray-500">{meta.local}</p>
+            </div>
+            <button onClick={() => onRemove(assignment.id)} className="text-red-500">Remove</button>
+        </div>
+    );
+}
+
+export default function FullCostCodeAllocator({ costCodes, laborers, assignments: initialAssignments }) {
+    const [assignments, setAssignments] = useState(initialAssignments || []);
+    const assignedLaborerIds = useMemo(() => new Set(assignments.map(a => a.laborerId)), [assignments]);
+
+    const unassignedByLocal = useMemo(() => {
+        const map = {};
+        laborers.forEach(l => {
+            if (!assignedLaborerIds.has(l.id)) {
+                if (!map[l.local]) map[l.local] = [];
+                map[l.local].push(l);
+            }
+        });
+        return map;
+    }, [laborers, assignedLaborerIds]);
+
+    const onDragEnd = ({ destination, source, draggableId }) => {
+        if (!destination) return;
+        const [type, id] = draggableId.split(':');
+        if (type === 'lab') {
+            const targetCostCodeId = destination.droppableId;
+            if (!targetCostCodeId.startsWith('costcode-')) return;
+            const laborer = laborers.find(l => l.id === id);
+            if (laborer && !assignedLaborerIds.has(laborer.id)) {
+                setAssignments(prev => [...prev, { id: Date.now().toString(), laborerId: laborer.id, costCodeId: targetCostCodeId, hours: laborer.original_hours }]);
+            }
+        }
+    };
+
+    const handleRemove = (id) => {
+        setAssignments(prev => prev.filter(a => a.id !== id));
+    };
+
+    return (
+        <div className="flex gap-4">
+            <DragDropContext onDragEnd={onDragEnd}>
+                <div className="w-1/3 p-2 bg-gray-200 rounded overflow-y-auto" style={{ maxHeight: '80vh' }}>
+                    {Object.entries(unassignedByLocal).map(([loc, labs]) => (
+                        <div key={loc} className="mb-4">
+                            <h3 className="font-medium text-sm mb-2">{loc}</h3>
+                            {labs.map((l, index) => (
+                                <Draggable key={l.id} draggableId={`lab:${l.id}`} index={index}>
+                                    {(prov) => (
+                                        <div ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps} className="bg-white rounded p-2 mb-2 shadow">
+                                            {l.name}
+                                        </div>
+                                    )}
+                                </Draggable>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+                <div className="flex-1 overflow-y-auto p-2" style={{ maxHeight: '80vh' }}>
+                    {costCodes.map(cc => (
+                        <div key={cc.id} className="mb-4 bg-gray-50 p-2 rounded border">
+                            <h3 className="font-semibold text-sm mb-2">{cc.code} - {cc.name}</h3>
+                            <Droppable droppableId={cc.id}>
+                                {(provided) => (
+                                    <div ref={provided.innerRef} {...provided.droppableProps} className="min-h-[40px]">
+                                        {assignments.filter(a => a.costCodeId === cc.id).map((a, idx) => {
+                                            const m = laborers.find(l => l.id === a.laborerId);
+                                            if (!m) return null;
+                                            return (
+                                                <Draggable key={a.id} draggableId={`assign:${a.id}`} index={idx}>
+                                                    {(prov) => (
+                                                        <div ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps}>
+                                                            <AssignmentCard assignment={a} meta={m} onRemove={handleRemove} />
+                                                        </div>
+                                                    )}
+                                                </Draggable>
+                                            );
+                                        })}
+                                        {provided.placeholder}
+                                    </div>
+                                )}
+                            </Droppable>
+                        </div>
+                    ))}
+                </div>
+            </DragDropContext>
+        </div>
+    );
+}

--- a/Contracker/resources/js/Layouts/SidebarLayout.jsx
+++ b/Contracker/resources/js/Layouts/SidebarLayout.jsx
@@ -1,0 +1,64 @@
+import { Link, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import ApplicationLogo from '@/Components/ApplicationLogo';
+
+export default function SidebarLayout({ header, children }) {
+    const { auth } = usePage().props;
+    const user = auth.user;
+    const [open, setOpen] = useState(false);
+
+    const links = [
+        { name: 'Dashboard', href: route('dashboard') },
+        { name: 'Device Management', href: route('devices.list') },
+        { name: 'Jobs', href: route('jobs.list') },
+        { name: 'Geofences', href: route('geofences.admin') },
+        { name: 'Timeclock', href: route('timeclock') },
+        { name: 'Message Search', href: route('messages.search') },
+        { name: 'Remote Control', href: route('remote.control') },
+    ];
+
+    const isActive = (href) => route().current(href.split('/').pop());
+
+    return (
+        <div className="flex h-screen overflow-hidden bg-gray-100 dark:bg-gray-900">
+            <div className={`fixed inset-y-0 left-0 z-40 w-60 transform bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transition-transform duration-200 ease-in-out ${open ? 'translate-x-0' : '-translate-x-full sm:translate-x-0'}`}
+            >
+                <div className="h-16 flex items-center px-4 border-b border-gray-200 dark:border-gray-700">
+                    <Link href="/">
+                        <ApplicationLogo className="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200" />
+                    </Link>
+                </div>
+                <nav className="flex-1 px-4 py-4 space-y-1 overflow-y-auto">
+                    {links.map((link) => (
+                        <Link
+                            key={link.name}
+                            href={link.href}
+                            className={`block px-2 py-2 rounded-md text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-900 ${isActive(link.href) ? 'font-semibold text-gray-900 dark:text-white' : 'text-gray-600 dark:text-gray-300'}`}
+                        >
+                            {link.name}
+                        </Link>
+                    ))}
+                </nav>
+                <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400">
+                    <div>{user.name}</div>
+                    <div className="text-xs">{user.email}</div>
+                </div>
+            </div>
+            <div className="flex flex-col flex-1 overflow-hidden ml-0 sm:ml-60">
+                <div className="sm:hidden bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-2">
+                    <button onClick={() => setOpen(!open)} className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">
+                        <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                    </button>
+                </div>
+                {header && (
+                    <header className="bg-white dark:bg-gray-800 shadow">
+                        <div className="px-4 py-4 sm:px-6 lg:px-8">{header}</div>
+                    </header>
+                )}
+                <main className="flex-1 overflow-y-auto p-4">{children}</main>
+            </div>
+        </div>
+    );
+}

--- a/Contracker/resources/js/Pages/CostCodeAllocator.jsx
+++ b/Contracker/resources/js/Pages/CostCodeAllocator.jsx
@@ -1,32 +1,26 @@
-import { useEffect } from 'react';
-import AppLayout from '@/Layouts/AppLayout';
-
+import { useEffect, useState } from 'react';
+import SidebarLayout from '@/Layouts/SidebarLayout';
 import axios from 'axios';
+import FullCostCodeAllocator from '../Allocator/FullCostCodeAllocator.jsx';
 
 export default function CostCodeAllocator({ jobId }) {
-  useEffect(() => {
-    Promise.all([
-      import('react'),
-      import('react-dom/client'),
-      import('react-beautiful-dnd'),
-      axios.get(route('costcode.allocator.data', { jobId })),
-    ]).then(([React, ReactDOM, RBD, res]) => {
-      window.React = React;
-      window.ReactDOM = ReactDOM;
-      window.ReactBeautifulDnd = RBD;
-      window.ALLOCATOR_DATA = res.data;
-      import('../Allocator/CostCodeAllocatorApp.jsx');
+    const [data, setData] = useState(null);
 
-lt(el, window.ALLOCATOR_DATA);
+    useEffect(() => {
+        axios.get(route('costcode.allocator.data', { jobId }))
+            .then(res => setData(res.data))
+            .catch(err => console.error('Failed to load allocator data', err));
+    }, [jobId]);
 
-    });
-  }, [jobId]);
-
-  return (
-    <AppLayout header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Cost Code Allocator</h2>}>
-      <div className="py-6">
-        <div id="root"></div>
-      </div>
-    </AppLayout>
-  );
+    return (
+        <SidebarLayout header={<h2 className="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">Cost Code Allocator</h2>}>
+            <div className="py-6">
+                {data ? (
+                    <FullCostCodeAllocator {...data} />
+                ) : (
+                    <p>Loading...</p>
+                )}
+            </div>
+        </SidebarLayout>
+    );
 }

--- a/Contracker/resources/js/Pages/Dashboard.jsx
+++ b/Contracker/resources/js/Pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import SidebarLayout from '@/Layouts/SidebarLayout';
 import UserSessionManager from '@/Components/UserSessionManager';
 import { Head, Link } from '@inertiajs/react';
 import DeviceInfo from '@/Components/DeviceInfo';
@@ -6,7 +6,7 @@ import DeviceMap from '@/Components/DeviceMap';
 
 export default function Dashboard() {
     return (
-        <AuthenticatedLayout
+        <SidebarLayout
             header={
                 <h2 className="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200">
                     Dashboard
@@ -36,6 +36,6 @@ export default function Dashboard() {
                     </div>
                 </div>
             </div>
-        </AuthenticatedLayout>
+        </SidebarLayout>
     );
 }


### PR DESCRIPTION
## Summary
- add sidebar layout with navigation links
- switch dashboard to sidebar layout
- replace cost code allocator with React implementation using sidebar
- seed demo jobs, cost codes, laborers and an assignment

## Testing
- `composer install` *(fails: composer.lock invalid)*
- `php artisan test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_6889499ad1848327aa3be8a4051c8fa4